### PR TITLE
Fixes font family inconsistency on the Methods page

### DIFF
--- a/methods.qmd
+++ b/methods.qmd
@@ -71,7 +71,7 @@ L = require('leaflet@1.9.4')
 html`<link href='${resolve('leaflet@1.2.0/dist/leaflet.css')}' rel='stylesheet' />`
 
 bootstrap=require("bootstrap")
-css=html`<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">`
+// css=html`<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0/dist/css/bootstrap.min.css" integrity="sha384-gH2yIJqKdNHPEq0n4Mqa/HGKIhSkIHeL5AyhkYV8i59U5AR6csBvApHHNl/vI1Bx" crossorigin="anonymous">`
 ```
 
 ```{ojs}


### PR DESCRIPTION
Importing of the bootstrap CSS style sheet in an OJS block caused an overriding of the default sans serif font family. Removing the CSS call does not appear to break any functionality.