### PR TITLE
Add link to PDF to web book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,18 @@ dev_*
 *_cache/
 _site/
 _book/
+README_files/
+capacity_files/
+consumption_files/
+generation_files/
+prices_files/
+*.html
+*.aux
+*.lof
+*.log
+*.lot
+*.tex
+*.toc
 
 node_modules/
 

--- a/README.md
+++ b/README.md
@@ -1,28 +1,49 @@
 # AETR Web Book
-Preliminary Alaska Electricity Trends Report as a web book.
 
+Preliminary Alaska Electricity Trends Report as a web book.
 
 ## Preview and Render Locally
 
+### Prepare the environment
 
-[Website Previewing](https://quarto.org/docs/websites/#website-preview) allows viewing of the completed website by generating HTML from the `qmd` files. VSCode and RStidio both render and preview pages automatically using a `Render` button.
+Rendering this web-book requires R (>=4.4.0) and some R packages.
 
-To preview the website using commands in the terminal:
+1. Install R from [The Comprehensive R Archive Network](https://cran.r-project.org) using the correct method for your operating system.
+2. Install OpenSSL, which is required for one of the packages.
+
+3. Issue these commands on your command line (or however you access R) to prepare your R environment using `renv`:
+
+  ``` bash
+  % cd aetr-web-book-2024/
+  % R    # at the command line to start R
+  > renv::restore()
+  ```
+
+4. The Barlow font must be installed.  
+
+
+### Previewing
+
+[Web-book Previewing](https://quarto.org/docs/websites/#website-preview) allows viewing of the completed website by generating HTML from the `qmd` files.  To preview the web-book using commands in the terminal:
+
 ``` bash
-# preview the website in the current directory
+# preview the web-book in the current directory
 quarto preview
 ```
+
 It should automatically open a browser window. See `quarto preview help` for hints
 
-You can also render the website without displaying it. The generated code goes in the `_site` directory (which should be listed in .gitignore)
+You can also render the web-book without displaying it. The generated code goes in the `_book` directory (which should be listed in .gitignore)
+
 ``` bash
 # render the website in the current directory
 quarto render 
 ```
 
+VSCode and RStudio both render and preview pages automatically using a `Render` button. In VSCode, open a `.qmd` page in the editor such as `index.qmd`, and 
+
 ## Publishing via GitHub
 
-Set things up (or is that the cc business)
 
 
 ## Credits

--- a/README.md
+++ b/README.md
@@ -9,9 +9,16 @@ Preliminary Alaska Electricity Trends Report as a web book.
 Rendering this web-book requires R (>=4.4.0) and some R packages.
 
 1. Install R from [The Comprehensive R Archive Network](https://cran.r-project.org) using the correct method for your operating system.
-2. Install OpenSSL, which is required for one of the packages.
 
-3. Issue these commands on your command line (or however you access R) to prepare your R environment using `renv`:
+2. Install OpenSSL, which is required for one of the packages. 
+
+3. The [Barlow font (Regular and Bold)](https://github.com/google/fonts/blob/main/ofl/barlow/) must be installed on your machine. This will be different for different operating systems.
+  
+   1. For Macs, follow the instructions for [installing fonts via Font Book](https://support.apple.com/guide/font-book/install-and-validate-fonts-fntbk1000/mac)
+
+   2. For Linux, manually perform the commands listed in this project's [GitHub Workflow](https://github.com/eldobbins/aetr-web-book-2024/blob/b3c9762e4528243bef33a7e09d1e52dabc206602/.github/workflows/quarto-publish.yml#L51)
+
+4. Issue these commands on your command line (or however you access R) to prepare your R environment using `renv`:
 
   ``` bash
   % cd aetr-web-book-2024/
@@ -19,35 +26,28 @@ Rendering this web-book requires R (>=4.4.0) and some R packages.
   > renv::restore()
   ```
 
-4. The Barlow font must be installed.  
+### Previewing Locally
 
+[Web book Previewing](https://quarto.org/docs/websites/#website-preview) describes viewing the website locally by using `quarto preview` on the command line to generate HTML from the `qmd` files. The generated HTML code goes in the `_book/` directory. It should also automatically open a browser window. See `quarto preview help` for hints.
 
-### Previewing
+However, we use [Profiles](https://github.com/acep-uaf/aetr-web-book-2024/wiki/Quarto-Profiles) in this repository with three different configuration files which complicates local previewing somewhat.
 
-[Web-book Previewing](https://quarto.org/docs/websites/#website-preview) allows viewing of the completed website by generating HTML from the `qmd` files.  To preview the web-book using commands in the terminal:
+1. `_quarto.yml` = the main configuration file that triggers the other two
+2. `_quarto-html.yml` = configures the web book
+3. `_quarto-pdf.yml` = configures the PDF report
 
-``` bash
-# preview the web-book in the current directory
-quarto preview
-```
+If the default profile is not set in `_quarto.yml`, the `quarto preview` renders both, one after the other; however the second render clobbers the first so you can only view HTML or PDF depending on the order of the profile group. So in our case, it is better to specify which format you want to render with `quarto preview --profile html` or `quarto preview --profile pdf`, or to toggle `default` between the two by editing `_quarto.yml`.
 
-It should automatically open a browser window. See `quarto preview help` for hints
-
-You can also render the web-book without displaying it. The generated code goes in the `_book` directory (which should be listed in .gitignore)
-
-``` bash
-# render the website in the current directory
-quarto render 
-```
-
-VSCode and RStudio both render and preview pages automatically using a `Render` button. In VSCode, open a `.qmd` page in the editor such as `index.qmd`, and 
+VSCode and RStudio both render and preview pages automatically using a `Preview` button. In VSCode, open a `.qmd` page in the editor such as `index.qmd`, and hit shift-command-K to preview the page.
 
 ## Publishing via GitHub
 
+This project includes a [GitHub Workflow](https://github.com/eldobbins/aetr-web-book-2024/blob/b3c9762e4528243bef33a7e09d1e52dabc206602/.github/workflows/quarto-publish.yml) that renders the Markdown as HTML and PDF and posts those to the `gh-pages` branch to create a website.  You can see in that workflow that the two profiles are rendered sequentially with the PDF subsequently copied into the `gh-pages` branch to avoid the clobbering issue noted locally.
 
+Note that rendered files and directories containing rendered files should be listed in `.gitignore` so they don't get copied into the GitHub repo. The presence of those files causes GitHub Actions to choke which breaks the generation and posting of the web book.
 
 ## Credits
 
 Website format is based on the [Quarto Website Tutorial](https://openscapes.github.io/quarto-website-tutorial/) developed by [Openscapes](https://openscapes.org/). Code is avalable in the [tutorial GitHub repo](https://github.com/Openscapes/quarto-website-tutorial/tree/main).
 
-This project was created using the [cookiecutter-quarto-website](https://github.com/eldobbins/cookiecutter-quarto-website) template that utilizes the [Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/README.html) project
+This project was created using the [cookiecutter-quarto-website](https://github.com/eldobbins/cookiecutter-quarto-website) template that utilizes the [Cookiecutter](https://cookiecutter.readthedocs.io/en/stable/README.html) project, but has many extensions not included in that template.

--- a/_quarto-html.yml
+++ b/_quarto-html.yml
@@ -52,6 +52,7 @@ format:
     code-copy: true
     code-overflow: wrap
     css: styles.css
+    email-obfuscation: javascript
     # fig-align: center  Tried this but it overridden by Observable defaults (bootstrap?) 
     number-depth: 2
     theme:

--- a/_quarto-html.yml
+++ b/_quarto-html.yml
@@ -9,6 +9,7 @@ book:
       text: Alaska Energy Statistics Workbooks (2011-2021)
       icon: bi-file-spreadsheet
   repo-actions: [issue]
+  downloads: pdf
 
   chapters:
     - index.qmd

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,5 +20,6 @@ warning: false
 cap-location: top
 
 profile:
+  default: html  # toggle this to choose which profile to render if neither is specified
   group: 
     - [pdf, html]

--- a/consumption.qmd
+++ b/consumption.qmd
@@ -248,7 +248,7 @@ print(customers_pdf)
 
 `r space()`
 
-`r if (knitr::is_html_output())"@fig-sales_per_capita-html" else if (knitr::is_latex_output()) "@fig-sales_per_capita-pdf"` <!--orig: The following table--> shows the average annual electricity consumption for each of the regions. The Coastal region led the state in consumption per capita, with an average of `r regional_consumption_per_capita("Coastal","Residential")` kWh per customer per year. This was followed by the Railbelt region with `r regional_consumption_per_capita("Railbelt","Residential")` kWh per capita and the Rural Remote region with `r regional_consumption_per_capita("Rural Remote","Residential")` kWh per capita. Overall, each region has seen reductions in consumption per capita, which may reflect improvements in energy efficient technologies and energy efficiency/conservation behaviors.
+`r if (knitr::is_html_output())"@fig-sales_per_capita-html" else if (knitr::is_latex_output()) "@fig-sales-per-capita-pdf"` <!--orig: The following table--> shows the average annual electricity consumption for each of the regions. The Coastal region led the state in consumption per capita, with an average of `r regional_consumption_per_capita("Coastal","Residential")` kWh per customer per year. This was followed by the Railbelt region with `r regional_consumption_per_capita("Railbelt","Residential")` kWh per capita and the Rural Remote region with `r regional_consumption_per_capita("Rural Remote","Residential")` kWh per capita. Overall, each region has seen reductions in consumption per capita, which may reflect improvements in energy efficient technologies and energy efficiency/conservation behaviors.
 
 `r space()`
 
@@ -317,7 +317,7 @@ girafe(code = print(sales_per_capita_html))
 ```
 
 ```{r, eval=knitr::is_latex_output(), fig.pos = "H"}
-#| label: fig-sales_per_capita-pdf
+#| label: fig-sales-per-capita-pdf
 #| fig-cap: "Average Residential Sales per Customer"
 
 sales_per_capita_pdf <- 

--- a/methods.qmd
+++ b/methods.qmd
@@ -237,4 +237,4 @@ Please visit the Alaska Energy Authority  [PCE webpage](https://www.akenergyauth
 
 ## Feedback Regarding Potential Errors
 
-Since these data come from multiple sources, there is potential for errors in its compilation. An integral part of this effort is the creation of a high quality dataset that can constructively contribute to future work. Therefore, any discrepancies or noted errors should be reported using email or GitHub issues via the links in the right hand navigation menu of every page. Alternatively, direct contact information for members of the DCM team is listed in @sec-contacts.
+Since these data come from multiple sources, there is potential for errors in its compilation. An integral part of this effort is the creation of a high quality dataset that can constructively contribute to future work. Therefore, any discrepancies or noted errors should be reported by emailing [support](mailto:uaf-acep-dcm-support@alaska.edu) or submitting a GitHub issue via the links in the right hand navigation menu of every page of the web book. Alternatively, direct contact information for members of the DCM team is listed in @sec-contacts. 

--- a/scripts/latex/before-body.tex
+++ b/scripts/latex/before-body.tex
@@ -75,4 +75,4 @@ J. Kaczmarski et al., “2024 Alaska Energy Trends Report,” Alaska Center for 
 \\
 \small This report is available at no cost from the Alaska Center for Energy and Power (ACEP) at the University of Alaska, Fairbanks (UAF) at www.uaf.edu/acep/our-resources/index.php. \\
 \\
-\small Cover photo courtesy of Frontier Suites
+\small Cover photo is the Salmon Creek Dam in Juneau, courtesy of Sarah Traiger.


### PR DESCRIPTION
This PR is mostly me getting sync'd with the recent updates. I did modify a couple things in the process:

- added a link to the PDF under the gear icon on every page of the web book
- updated the photo credit in the PDF
- refined the language for submitting feedback to be platform agnostic (I think)
- changed the name of one PDF figure to remove "_" in the filename because that was  crashing my local PDF builds
- update the README to be more helpful and relevant to previewing PDFs and HTML locally.