### PR TITLE
Font and alignment fixes

### DIFF
--- a/_quarto-pdf.yml
+++ b/_quarto-pdf.yml
@@ -28,6 +28,7 @@ format:
     fig-height: 3.25
 
     fontsize: 11pt
+    mainfont: Barlow
 
     toc: true   
     toc-depth: 3

--- a/scripts/latex/preamble.tex
+++ b/scripts/latex/preamble.tex
@@ -1,16 +1,8 @@
 \usepackage{graphicx}
 \usepackage{fancyhdr}
 \usepackage{xcolor}
-\usepackage[T1]{fontenc}
-\usepackage{fontspec}
 
 \usepackage[margin=2cm, bottom=2cm, top=3cm, headheight=50pt, footskip=20pt]{geometry} 
-
-% Set font to Barlow
-\setmainfont{Barlow}
-
-% Styling
-\renewcommand\familydefault{\sfdefault}
 
 % Define colors
 \definecolor{uafblue}{HTML}{104179} 
@@ -24,7 +16,7 @@
     \makebox[0pt][c]{\hspace*{0cm}\color{uafblue}\rule{\dimexpr\textwidth+2cm\relax}{40pt}}
     \makebox[0pt][c]{\hspace*{-0.25cm}\color{uafyellow}\rule{\dimexpr\textwidth+2cm\relax}{5pt}}
   }
-  \fancyhead[R]{\raisebox{17pt}{\color{white} \textbf{\fontsize{14}{16}\selectfont Alaska Electricity Trends Report, 2024}}}
+  \fancyhead[R]{\raisebox{17pt}{\color{white} \textbf{\fontsize{14}{16} Alaska Electricity Trends Report, 2024}}}
   \fancyfoot[R]{\raisebox{0pt}{\color{uafblue} \textbf{\thepage}}}
   \renewcommand{\headrulewidth}{0pt}
   \renewcommand{\footrulewidth}{0pt}

--- a/scripts/latex/preamble.tex
+++ b/scripts/latex/preamble.tex
@@ -14,7 +14,7 @@
   \fancyhf{}
   \fancyhead[C]{
     \makebox[0pt][c]{\hspace*{0cm}\color{uafblue}\rule{\dimexpr\textwidth+2cm\relax}{40pt}}
-    \makebox[0pt][c]{\hspace*{-0.25cm}\color{uafyellow}\rule{\dimexpr\textwidth+2cm\relax}{5pt}}
+    \makebox[0pt][c]{\hspace*{-0.145cm}\color{uafyellow}\rule{\dimexpr\textwidth+2cm\relax}{5pt}}
   }
   \fancyhead[R]{\raisebox{17pt}{\color{white} \textbf{\fontsize{14}{16} Alaska Electricity Trends Report, 2024}}}
   \fancyfoot[R]{\raisebox{0pt}{\color{uafblue} \textbf{\thepage}}}


### PR DESCRIPTION
Commit b5aa825 removes some overwriting issues with LaTeX and makes sure the local PDF renders with Barlow (must still be installed).

Commit 8c9ec3b aligns the blue and yellow header. I had noticed the yellow header was off by just a little bit so I reset it's location.