### PR TITLE
Fix fonts and page spacing

### DIFF
--- a/_quarto-pdf.yml
+++ b/_quarto-pdf.yml
@@ -22,7 +22,7 @@ format:
   pdf:
     pdfengine: xelatex
     documentclass: scrreprt
-    papersize: a4
+    papersize: letter
 
     fig-width: 6
     fig-height: 3.25

--- a/scripts/latex/before-body.tex
+++ b/scripts/latex/before-body.tex
@@ -14,11 +14,11 @@ $if(title)$
 
 \makebox[\textwidth]{\includegraphics[width=\textwidth+2cm]{images/banner_acep_uaf.png}}
 
-\vspace{5ex}
+\vspace{3ex}
 
 \par\noindent\hspace*{-1cm}\includegraphics[width=\textwidth+2cm]{images/salmon_creek_dam.jpeg}
 
-\vspace{5ex}
+\vspace{3ex}
 
 % \begin{flushright} % uncomment if you want all text on one side
 
@@ -26,7 +26,7 @@ $if(title)$
 \vspace{2ex}
 {\large\bfseries\color{uafblue} $subtitle$ \par}
 
-\vspace{5ex}
+\vspace{3ex}
 
 {\normalsize
   Jesse Kaczmarski \textsuperscript{1}, 
@@ -40,7 +40,7 @@ $if(title)$
 
 \vspace{5ex}
 
-{\large
+{\normalsize
   \textsuperscript{1} Alaska Center for Energy and Power, UAF \\
   \textsuperscript{2} DOWL \\
   \textsuperscript{3} Office of the Vice Chancellor for Research, UAF
@@ -62,7 +62,7 @@ August 2024 \\
 Suggested Citation: \\
 Kaczmarski, J., I. Yeager, S. Colt, E. L. Dobbins, N. McMahon, S. Fisher-Goad, and B. Smart. “2024 Alaska Energy Trends Report,” Alaska Center for Energy and Power, University of Alaska, Fairbanks, 2024. UAF/ACEP/number. DOI:number. 
 
-% \newpage
+\newpage
 % \thispagestyle{empty}
 \vspace{30ex}
 \noindent


### PR DESCRIPTION
This fixes the font size of affiliations spilling over to the next page. This is likely the result of having changed from A4 paper size to Letter size.